### PR TITLE
Add missing keyword identifier

### DIFF
--- a/DCF77ISR/keywords.txt
+++ b/DCF77ISR/keywords.txt
@@ -5,10 +5,8 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-Dcf77Analyser
+Dcf77Analyser	KEYWORD1
 
-
-	
 DCF77ISR	KEYWORD1
 DCF77_LED_REPLICAPIN	KEYWORD1
 DCF77_PARTIALOK	KEYWORD1


### PR DESCRIPTION
The keywords are not recognized by the Arduino IDE for special highlighting without the identifiers.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype